### PR TITLE
Cartão cidadão não funciona em aeroportos

### DIFF
--- a/em-portugal/estatuto-de-igualdade.md
+++ b/em-portugal/estatuto-de-igualdade.md
@@ -13,7 +13,6 @@ e outras pequenas facilidades, tais como:
 
 * marcação de consultas no Sistema Nacional de Saúde online, sem precisar ligar para o Centro de Saúde;
 * autenticação de documentos online com a chave privada associada ao cartão;
-* fast track na imigração dos aeroportos, você pode pegar a fila de cidadão europeu;
 * login facilitado nas plataformas online do governo.
 
 Note que tanto o Cartão Cidadão português para estrangeiros quanto o Título de Residência não são aceitos como documentos válidos de viagem, então mesmo em viagens dentro do Espaço Schengen você irá precisar do seu passaporte.


### PR DESCRIPTION
Testei agora em Dezembro e não pude passar nas catracas eletrônicas pra quem tem cartão cidadão e também apresentei o cartão ao SEF, que logo pediu a residência. Não sei se isso se refere apenas a passar na fila pra cidadão europeu, mas creio que não irão aceitar, visto que no cartão cidadão está escrito que não é válido para viagens.