### PR TITLE
remove globo information

### DIFF
--- a/dicas/assinaturas-streaming.md
+++ b/dicas/assinaturas-streaming.md
@@ -1,22 +1,4 @@
 # Assinaturas / Streaming
 
-Em geral, serviços como Spotify, Netflix, YouTube Premium, PSN Plus etc. tem preços mais vantajosos no Brasil do que em Portugal porque as empresas definem o valor da assinatura para se adequar mais à renda do consumidor médio do país. Manter assinaturas brasileiras em todos os serviços com um cartão português funciona sem problemas.
+Em geral, serviços como Spotify, Netflix, YouTube Premium, PSN Plus etc... tem preços mais vantajosos no Brasil do que em Portugal porque as empresas definem o valor da assinatura para se adequar mais à renda do consumidor médio do país. Manter assinaturas brasileiras em todos os serviços com um cartão português funciona sem problemas. 
 
-### Globo
-
-Caso você tenha interesse em acompanhar conteúdos da Globo, como telejornalismo, séries etc., recomendo a assinatura do Globoplay no Brasil, porque o canal Globo oferecido nos pacotes de TV por Assinatura não é o mesmo do Brasil e só passa novelas antigas (pegadinha!). Há inclusive uma opção de assinatura com os canais da Globosat, como GNT, Multishow etc.
-
-Há dois problemas que tornam a utilização um pouco chata, mas que são contornáveis: é necessária a utilização de VPN com conexão ao Brasil por questões de licenciamento ([se tentar reproduzir um vídeo sem VPN, aparece esta mensagem de erro](https://user-images.githubusercontent.com/397851/106726914-d1c13500-6602-11eb-9762-53a13c2cdad9.jpeg)) e a aplicação só está disponível no Brasil (o que torna as coisas mais chatas especialmente no caso do iOS).
-
-Para utilizar no celular, é necessário que a VPN esteja ligada no momento do início da reprodução, mas uma vez que o vídeo já esteja tocando é possível desligá-la; além disso, uma vez iniciada a reprodução, é possível compartilhar o vídeo com Smart TV / Chromecast / AirPlay ainda que o dispositivo esteja fora da VPN.
-
-#### **Globoplay no iPhone**
-
-A aplicação Globoplay só está disponível em contas Apple com endereço no Brasil. Até que a Globo publique a aplicação na App Store portuguesa, você precisará:
-
-1. Sair da sua conta Apple portuguesa e entrar com uma conta brasileira (precisará criar em um email secundário da primeira vez)
-2. Baixar ou atualizar o app
-3. Sair da sua conta Apple brasileira e entrar com a conta portuguesa
-4. Configurar novamente Apple Pay (uma vez que ao deslogar essas configurações são perdidas ao deslogar), incluindo para o Apple Watch.
-
-É um processo chato que leva cerca de 15 a 20 minutos. Após o lançamento de uma versão nova, [a aplicação exibe uma mensagem de erro "Ihhh, essa versão já ficou velhinha!", pedindo para atualizar](https://user-images.githubusercontent.com/397851/106725000-c836cd80-6600-11eb-9a59-da23c88da0f6.jpeg). Por um tempo é possível clicar em "Atualizar depois" e seguir utilizando, mas após algum tempo a sua versão não conseguirá mais acessar, e você precisará repetir os passos acima novamente.


### PR DESCRIPTION
Globoplay is now avaliable in Portugal, so no need of tweaks anymore to watch content