### PR TITLE
Atualiza procedimento da carteira de condução

### DIFF
--- a/em-portugal/carteira-de-motorista.md
+++ b/em-portugal/carteira-de-motorista.md
@@ -4,7 +4,7 @@
 
 Para quem tem Carteira de Motorista brasileira (CNH) não é mais necessário realizar a troca pela carteira de condução portuguesa. A partir de 01/08/2022 Portugal passou a aceitar título de condução de países membros da OCDE e CPLP (inclui o Brasil). É possível dirigir em Portugal com a CNH brasileira, desde que possua menos de 60 anos, e a última renovação ou emissão do título não tenha sido feita há mais de 15 anos. Além disso qualquer suspensão ou situação que invalide a CNH no Brasil, também invalida o seu uso em Portugal. Mais informações no site [IMT Online](http://www.imtonline.pt/index.php/troca-de-titulos-conducao-estrangeiros/troca-de-titulos-de-conducao109/9-uncategorised/2287-5-situacao-ocde-cplp)
 
-Ainda assim, caso queira proceder com a troca, há 2 procedimentos:
+Ainda assim, caso queira proceder com a troca (por exemplo, para dirigir em outros países da Europa, ou caso a data de validade esteja próxima), há 2 procedimentos:
 
 #### Para CNH expedida a partir de 18 de maio de 2017 (COM QR code no verso):
 

--- a/em-portugal/carteira-de-motorista.md
+++ b/em-portugal/carteira-de-motorista.md
@@ -2,13 +2,9 @@
 
 ### Troca da Carteira de Motorista Brasileira pela Carta de Condução Portuguesa
 
-Para quem tem Carteira de Motorista brasileira (CNH), existem dois prazos importantes. É possível dirigir em Portugal com a CNH brasileira - **não é exigida a Permissão Internacional para Dirigir** - num prazo de **183 dias após a chegada ao país**.
+Para quem tem Carteira de Motorista brasileira (CNH) não é mais necessário realizar a troca pela carteira de condução portuguesa. A partir de 01/08/2022 Portugal passou a aceitar título de condução de países membros da OCDE e CPLP (inclui o Brasil). É possível dirigir em Portugal com a CNH brasileira, desde que possua menos de 60 anos, e a última renovação ou emissão do título não tenha sido feita há mais de 15 anos. Além disso qualquer suspensão ou situação que invalide a CNH no Brasil, também invalida o seu uso em Portugal. Mais informações no site [IMT Online](http://www.imtonline.pt/index.php/troca-de-titulos-conducao-estrangeiros/troca-de-titulos-de-conducao109/9-uncategorised/2287-5-situacao-ocde-cplp)
 
-Após este prazo, há um segundo prazo para realizar a conversão da carteira brasileira para a carta de condução portuguesa, de **2 anos** a partir da data de chegada. Este prazo era de 3 meses, mas foi recentemente ampliado com o [Decreto-Lei nº 2/2020](https://dre.pt/home/-/dre/128071719/details/maximized).
-
-**Observação Importante:** a carteira de motorista é enviada para o endereço que consta no seu título de residência ou cartão cidadão; **não é possível solicitar o envio para outro endereço**. Caso seu endereço esteja desatualizado, sugiro primeiro verificar com o proprietário ou novo inquilino do imóvel antigo de receber a carta e te avisar do recebimento, ou fazer primeiro uma nova via do documento.
-
-Há 2 procedimentos:
+Ainda assim, caso queira proceder com a troca, há 2 procedimentos:
 
 #### Para CNH expedida a partir de 18 de maio de 2017 (COM QR code no verso):
 


### PR DESCRIPTION
A partir de 1 de agosto de 2022 o título de condução brasileiro é aceito em Portugal de forma permanente. Não é mais necessário realizar a troca para o título de condução português, seja o condutor turista ou residente.